### PR TITLE
Updated to upload-artifact@v4 due to deprecation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       run: pyinstaller main.py --noconsole --onefile --name amber-kawpow-miner --add-data "logo.ico;." --icon="logo.ico" --uac-admin
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: amber-kawpow-miner
         path: dist\amber-kawpow-miner.exe


### PR DESCRIPTION
Replaced `actions/upload-artifact@v2` with `actions/upload-artifact@v4` due to [deprecation](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/). No syntax changes appear to be required.